### PR TITLE
Preliminary Download Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # velocity-download-api
 Web API for velocity downloads written in python.
 
-# Example API Response
+# API Endpoints
+Base URL: https://velocity-download-api.herokuapp.com/
+<details close>
+<summary>/</summary>
+
+GET `/`
 ```json
 {
   "error": false,
-  "latest_release": "1.1.6",
+  "latest_release": "3.0.0",
   "latest_version": "4.0.0-SNAPSHOT",
   "stable_versions": [
+    "1.1.",
     "1.1.0",
     "1.1.1",
     "1.1.2",
     "1.1.3",
     "1.1.4",
     "1.1.5",
-    "1.1.6"
+    "1.1.6",
+    "1.1.7",
+    "1.1.8",
+    "1.1.9",
+    "3.0.0"
   ],
   "versions": [
+    "1.1.",
     "1.1.0-SNAPSHOT",
     "1.1.0",
     "1.1.1-SNAPSHOT",
@@ -32,12 +43,54 @@ Web API for velocity downloads written in python.
     "1.1.6-SNAPSHOT",
     "1.1.6",
     "1.1.7-SNAPSHOT",
+    "1.1.7",
+    "1.1.8-SNAPSHOT",
+    "1.1.8",
+    "1.1.9-SNAPSHOT",
+    "1.1.9",
+    "1.1.10-SNAPSHOT",
     "2.0.0-SNAPSHOT",
     "3.0.0-SNAPSHOT",
+    "3.0.0",
+    "3.0.1-SNAPSHOT",
     "4.0.0-SNAPSHOT"
   ]
 }
 ```
+</details>
+<details close>
+<summary>/version/{version}/</summary>
+
+GET `/version/3.0.0/`
+```json
+{
+  "download": {
+    "checksum": {
+      "md5": "55c20c0fdd74ae4a00af328a74f82724",
+      "sha1": "315ba63c9bee028234800f1b1317a503b96e7159",
+      "sha256": "2479f6915b43c63145f5b33d5c15eec491d60e31cccc685f4175afea7cc1b40c",
+      "sha512": "3dccfafa52a7972f7430522863f06e3544e41f770ee2ff5fde0c0c8afac343bcb87d9b2253d0ebbda9ac779eda72e0d8f1b9c4550ba5f2434d487ab957c00372"
+    },
+    "name": "velocity-native-3.0.0.jar",
+    "url": "https://nexus.velocitypowered.com/repository/maven-public/com/velocitypowered/velocity-native/3.0.0/velocity-native-3.0.0.jar"
+  },
+  "exists": true,
+  "snapshot": false,
+  "version": "3.0.0"
+}
+```
+</details>
+<details close>
+<summary>/version/{version}/download/</summary>
+
+GET `/version/3.0.0/download/`
+
+Redirects to: 
+```text
+https://nexus.velocitypowered.com/repository/maven-public/com/velocitypowered/velocity-native/3.0.0/velocity-native-3.0.0.jar
+```
+
+</details>
 
 # Deploying
 ##### Cloning the project

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, redirect
 from flask_caching import Cache
 
 import data_fetch
@@ -18,6 +18,24 @@ def index():
         latest_release=fetcher.latest_release,
         stable_versions=fetcher.stable_versions,
         error=fetcher.errored
+    )
+
+
+@app.route('/version/<version>/')
+def specific_version_meta(version: str):
+    return redirect(data_fetch.VelocityDownloadFetcher(version, extension=".module").url, 301)
+
+
+@app.route('/version/<version>/download')
+def specific_version_download(version: str):
+    return redirect(data_fetch.VelocityDownloadFetcher(version).url, 301)
+
+
+@app.route("/snapshot-error/")
+def snapshot_error():
+    return jsonify(
+        error=True,
+        message="SNAPSHOT versions are currently not supported."
     )
 
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, redirect
+from flask import Flask, jsonify, redirect, request
 from flask_caching import Cache
 
 import data_fetch
@@ -7,9 +7,11 @@ app = Flask(__name__)
 cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 cache.init_app(app)
 
+cache_time = 120  # 2 Minutes
+
 
 @app.route('/')
-@cache.cached(timeout=120)  # 2 minute cache should be fine
+@cache.cached(timeout=cache_time)
 def index():
     fetcher = data_fetch.VelocityVersionFetcher()
     return jsonify(
@@ -22,21 +24,33 @@ def index():
 
 
 @app.route('/version/<version>/')
+@cache.cached(timeout=cache_time)
 def specific_version_meta(version: str):
-    return redirect(data_fetch.VelocityDownloadFetcher(version, extension=".module").url, 301)
+    version_object = data_fetch.get_version(version)
+
+    return jsonify({
+        "version": version_object.version,
+        "exists": version_object.real,
+        "snapshot": version_object.snapshot,
+        "download": {
+            "url": version_object.url,
+            "name": version_object.relative_url,
+            "checksum": {
+                "sha512": version_object.velocity_file_sha512,
+                "sha256": version_object.velocity_file_sha256,
+                "sha1": version_object.velocity_file_sha1,
+                "md5": version_object.velocity_file_md5
+            }
+        }
+    })
 
 
-@app.route('/version/<version>/download')
+@app.route('/version/<version>/download/')
+@cache.cached(timeout=cache_time)
 def specific_version_download(version: str):
-    return redirect(data_fetch.VelocityDownloadFetcher(version).url, 301)
+    version_object = data_fetch.get_version(version)
 
-
-@app.route("/snapshot-error/")
-def snapshot_error():
-    return jsonify(
-        error=True,
-        message="SNAPSHOT versions are currently not supported."
-    )
+    return redirect(version_object.url)
 
 
 if __name__ == '__main__':

--- a/data_fetch.py
+++ b/data_fetch.py
@@ -43,3 +43,11 @@ class VelocityVersionFetcher:
             self.errored = False
         else:
             self.errored = True
+
+
+class VelocityDownloadFetcher:
+    def __init__(self, version: str, url: str = 'https://nexus.velocitypowered.com/repository/maven-public/com'
+                                                '/velocitypowered/velocity-native/', extension: str = ".jar"):
+        self.url = url + f"{version}/velocity-native-{version}{extension}"
+        if "-snapshot" in version.lower():
+            self.url = "/snapshot-error/"

--- a/data_fetch.py
+++ b/data_fetch.py
@@ -1,5 +1,10 @@
+import json
+
 import urllib3
 from bs4 import BeautifulSoup
+
+velocity_native_url = "https://nexus.velocitypowered.com/repository/maven-public/com/velocitypowered/velocity-native/"
+pool_manager = urllib3.PoolManager()
 
 
 class VelocityVersionFetcher:
@@ -15,7 +20,7 @@ class VelocityVersionFetcher:
         self.latest_release = None
         self.errored = False
 
-        self.http = urllib3.PoolManager()
+        self.http = pool_manager
 
         if perform_initial_fetch:
             self.fetch_data()
@@ -48,6 +53,60 @@ class VelocityVersionFetcher:
 class VelocityDownloadFetcher:
     def __init__(self, version: str, url: str = 'https://nexus.velocitypowered.com/repository/maven-public/com'
                                                 '/velocitypowered/velocity-native/', extension: str = ".jar"):
-        self.url = url + f"{version}/velocity-native-{version}{extension}"
+        self.url = f"{url}{version}/velocity-native-{version}{extension}"
         if "-snapshot" in version.lower():
             self.url = "/snapshot-error/"
+
+
+class VelocityVersion:
+    def __init__(self, real: bool, version: str, module_info: dict or None, base_url: str = velocity_native_url):
+        self.real = real
+
+        self.version = version
+        self.snapshot = "-SNAPSHOT" in version
+
+        self.relative_url = None
+        self.url = None
+        self.velocity_file_sha512 = None
+        self.velocity_file_sha256 = None
+        self.velocity_file_sha1 = None
+        self.velocity_file_md5 = None
+
+        if real:
+            velocity_file = module_info["variants"][0]["files"][0]  # Assume only 1 variant with 1 file
+
+            self.relative_url = velocity_file["url"]
+            self.url = f"{base_url}{version}/{self.relative_url}"
+            self.velocity_file_sha512 = velocity_file["sha512"]
+            self.velocity_file_sha256 = velocity_file["sha256"]
+            self.velocity_file_sha1 = velocity_file["sha1"]
+            self.velocity_file_md5 = velocity_file["md5"]
+
+
+def get_version(version: str, base_url: str = velocity_native_url,
+                http: urllib3.PoolManager = pool_manager) -> VelocityVersion:
+    version_url = base_url + version
+    version_url_module = f"{version_url}/velocity-native-{version}.module"
+
+    if "-SNAPSHOT" in version:
+        request = pool_manager.request("GET", f"{version_url}/maven-metadata.xml")
+        if request.status == 200:
+            raw_xml = request.data.decode("utf-8")
+            parsed_xml = BeautifulSoup(raw_xml, "lxml")
+
+            snapshot = parsed_xml.metadata.versioning.snapshot
+
+            snapshot_name = f"{version.replace('-SNAPSHOT', '')}-{snapshot.timestamp.text}-{snapshot.buildnumber.text}"
+
+            version_url_module = f"{velocity_native_url}{version}/velocity-native-{snapshot_name}.module"
+        else:
+            return VelocityVersion(False, version, None)
+
+    request = pool_manager.request('GET', version_url_module)
+
+    if request.status == 200:
+        module_info = json.loads(request.data.decode("utf-8"))
+
+        return VelocityVersion(True, version, module_info, base_url)
+    else:
+        return VelocityVersion(False, version, None)


### PR DESCRIPTION
Implements #2.

Adds API endpoints such as `/version/1.1.8/` and `/version/1.1.8/download/`

Doesn't support snapshot versions but if people want that I can probably bodge it in.